### PR TITLE
Issue #5 - Fixed ValueError: mutable default <class 'numpy.ndarray'> for field frequencies is not allowed: use default_factory

### DIFF
--- a/pyabsorp/material.py
+++ b/pyabsorp/material.py
@@ -69,7 +69,7 @@ class Material:
         title=cm.th_p_md[0], description=cm.th_p_md[1]))
     shape: str = field(default=None, metadata=dict(
         title=cm.shape_md[0], description=cm.shape_md[1]))
-    frequencies: np.ndarray = field(default=np.arange(100, 10001, 1),
+    frequencies: np.ndarray = field(default_factory=lambda: np.arange(100, 10001, 1),
                                     metadata=dict(title=cm.freq_md[0],
                                     description=cm.freq_md[1]))
 


### PR DESCRIPTION
The bug outlined in #5 is fixed by utilizing `default_factory` instead of `default`.
With this change, PyAbsorp works with python 3.12.3. 